### PR TITLE
Update HttpPusher to support multiple webhooks

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -26,7 +26,7 @@ author = "s0ph0s"
 # The short X.Y version
 version = "4.0"
 # The full version, including alpha/beta/rc tags
-release = "v4.1.0"
+release = "v5.0.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/conf.py
+++ b/conf.py
@@ -26,7 +26,7 @@ author = "s0ph0s"
 # The short X.Y version
 version = "4.0"
 # The full version, including alpha/beta/rc tags
-release = "v4.0.0"
+release = "v4.1.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/gelo.toml.example
+++ b/gelo.toml.example
@@ -5,37 +5,37 @@
 # user_plugin_dir
 # The location of additional plugins.  Environment variable expansion is
 # performed on this string value.
-user_plugin_dir=$HOME/.config/gelo/plugins
+user_plugin_dir="$HOME/.config/gelo/plugins"
 # log_file
 # The file to log to.  Environment variable expansion is performed on this
 # string value.
-log_file=$HOME/.config/gelo/gelo.log
+log_file="$HOME/.config/gelo/gelo.log"
 # macro_file
 # The file in which macros should be saved
-macro_file=$HOME/.config/gelo/macros.ini
+macro_file="$HOME/.config/gelo/macros.ini"
 # broadcast_delay
 # How long the system should wait before pushing markers from a source to all of
 # the sinks.
-broadcast_delay = 8.0
+broadcast_delay = "8.0"
 
 #
 # plugin:HttpPoller: Configure the HTTP poller metadata source
 #
-[plugin:HttpPoller]
+["plugin:HttpPoller"]
 # poll_url
 # The URL to poll for markers
-poll_url=http://localhost:8080/nowplaying.xsl
+poll_url="http://localhost:8080/nowplaying.xsl"
 # prefix_file
 # The place to look for the now playing prefix.  This is sort of a hack, unless
 # I find a better way of doing what I want to accomplish.  If there is any text
 # in parenthesis on the first line of this file, it will be added to the marker
 # as a special status field.
-prefix_file = /tmp/prefix.txt
+prefix_file = "/tmp/prefix.txt"
 
 #
 # plugin:Tweeter: Configure the Twitter plugin
 #
-[plugin:Tweeter]
+["plugin:Tweeter"]
 ########
 # NOTE #
 ########
@@ -51,178 +51,195 @@ prefix_file = /tmp/prefix.txt
 # consumer_key
 # The Twitter API key for this application, found under Keys and Access Tokens
 # on the Twitter Application Management page (apps.twitter.com)
-;consumer_key =
+;consumer_key =""
 # consumer_secret
 # The Twitter API secret for this application, found under Keys and Access
 # Tokens on the Twitter Application Management page (apps.twitter.com)
-;consumer_secret =
+;consumer_secret =""
 # access_token_key
 # The Twitter API access token to allow this app to tweet using your account,
 # found under Keys and Access Tokens on the Twitter Application Management page
 # (apps.twitter.com).
-;access_token_key =
+;access_token_key =""
 # access_token_secret
 # The Twitter API access token secret to allow this app to tweet using your
 # account, found under Keys and Access Tokens on the Twitter Application
 # Management page (apps.twitter.com).
-;access_token_secret =
+;access_token_secret =""
 
 # announce_string
 # The string that will be tweeted. "{marker}" will be substituted for the text
 # sent by the marker source.  "{special}" will be substituted for " (...)",
 # where the ellipsis is any special status attached to the marker.
-announce_string=Now Playing{special}: {marker}
+announce_string="Now Playing{special}: {marker}"
 # delayed
 # Delay this plugin's output by the broadcast delay from above? Default True
-;delayed = True
+;delayed = "True"
 
 #
 # plugin:NowPlayingFile: A text file that contains a single line with the
 # current marker data
 #
-[plugin:NowPlayingFile]
+["plugin:NowPlayingFile"]
 # path
 # The path to write the now playing file to.  Environment variable expansion is
 # performed on this string value.
-path=$HOME/Desktop/np.txt
+path="$HOME/Desktop/np.txt"
 # delayed
 # Delay this plugin's output by the broadcast delay from above? Default False
-;delayed = False
+;delayed = "False"
 
 
 #
 # plugin:IRC: Configure the IRC client plugin
 #
-[plugin:IRC]
+["plugin:IRC"]
 # nick
 # The IRC nick to use when connecting
-nick=gelo
+nick="gelo"
 # nickserv_pass
 # The password to use when authenticating with NickServ. Set to the empty string
 # if you don't need that feature.
-nickserv_pass=
+nickserv_pass=""
 # server
 # The IRC server to connect to
-server=irc.example.com
+server="irc.example.com"
 # port
 # The TCP port to connect to on the IRC server
-port=6697
+port="6697"
 # tls
 # Enable TLS for the IRC connection.  Probably also in combination with
-# port=6697
-tls=True
+# port="6697"
+tls="True"
 # ipv6
 # Force the IRC connection over IPv6. I'm not entirely sure what the underlying
 # framework does with this, so maybe it falls back intelligently?
-ipv6=True
+ipv6="True"
 # send_to
 # The nick (or channel) to which to send messages
-send_to=#test
+send_to="#test"
 # repeat_with
 # Repeat the message with these strings (usually channels, although you could
 # get creative with it...).  Separate items with a comma. To disable this
 # behavior and just send one message, comment out this key.
-;repeat_with=#channel,#channel2,#channel3
+;repeat_with="#channel,#channel2,#channel3"
 # message
 # The message to send. The group {marker} will be replaced with the marker text.
 # The group {special} will be replaced with a special indicator, if the marker
 # has a special status. The indicator has a space before it, so take that into
 # account when creating this string. If repeat_with is defined, the message will
 # be repeated, each time substituting in one of the items for {item}.
-message=Now Playing{special}: {marker}
+message="Now Playing{special}: {marker}"
 # delayed
 # Delay this plugin's output by the broadcast delay from above? Default True
-;delayed = True
+;delayed = "True"
 
 #
 # plugin:AudacityLabels: Configure the Audacity Labels plugin
 #
-[plugin:AudacityLabels]
+["plugin:AudacityLabels"]
 # path
 # The path to write the file to. Environment variable expansion is performed on
 # this string value, and "{show}" will be replaced by the show that Gelo was
 # started with. Additionally, "{count}" will be replaced with a 4-character,
 # zero-padded number to avoid overwriting existing files with the same name.
 # Audacity expects this file to end with ".txt".
-path=$HOME/Desktop/{show}-{count}.txt
+path="$HOME/Desktop/{show}-{count}.txt"
 # delayed
 # Delay this plugin's output by the broadcast delay from above? Default False
-;delayed = False
+;delayed = "False"
 
 #
 # plugin:HttpPusher: Configure the HTTP Pusher plugin
 #
-[plugin:HttpPusher]
+["plugin:HttpPusher"]
+# delayed
+# Delay this plugin's output by the broadcast delay from above? Default False
+;delayed = "False"
+
+# One of the webhooks for the HTTP Pusher plugin to send a request to.
+# Make more by copying this section and changing "example" in the section header to the
+# name that you'd like your new webhook to have.
+["plugin:HttpPusher".webhooks.example]
 # url
 # The URL to connect to, with no arguments. HTTPS is supported.
-url = https://example.com/now_playing
+url = "https://example.com/now_playing"
 # method
 # The HTTP method that the endpoint expects you to use. Currently only GET and
 # POST are supported, and you should *really* be using POST.
-method = POST
+method = "POST"
 # api_key_param
 # The argument name where the endpoint expects to find an API key, because it's
 # not just exposed to the public, right? If your system is bad, comment this key
 # out to disable sending an API key.
-api_key_param = api_key
+api_key_param = "api_key"
 # api_key
 # The API key to send, for authentication purposes.
-api_key = nonsense
+api_key = "nonsense"
 # marker_param
 # The argument name where the endpoint expects to find the marker text.
-marker_param = song
-# delayed
-# Delay this plugin's output by the broadcast delay from above? Default False
-;delayed = False
+marker_param = "song"
+# show_slug_param
+# The argument name where the endpoint expects to find the show slug.  Comment this key
+out to disable sending the show slug.
+show_slug_param = "slug"
+# show_episode_param
+# The argument name where the endpoint expects to find the episode of the show.  Comment
+# this key out to disable sending the episode number.  (Note that episode numbers are
+# not always numeric. See -x episodes.)
+show_episode_param = "episode"
+# extra_delay
+# Add more delay before sending markers to this webhook.  Positive delays only.
+extra_delay = "8.0"
 
 #
 # plugin:SomaFM: Configure the SomaFM plugin
 #
-[plugin:SomaFM]
+["plugin:SomaFM"]
 # stream_url
 # The URL of the SomaFM stream to connect to.  Must be a direct link, not a
 # playlist link.  Also, only HTTP MP3 streams are supported, because they're
 # really easy to decode metadata from.
-stream_url = http://ice1.somafm.com/groovesalad-128-mp3
+stream_url = "http://ice1.somafm.com/groovesalad-128-mp3"
 # source_name
 # The bit in parentheses when this track is announced.
-source_name = from Groove Salad on Soma.FM
+source_name = "from Groove Salad on Soma.FM"
 # extra_delay
 # A floating-point number of seconds to delay announcements for.  Useful for
 # compensating for streaming delays from Soma.FM to you.
-extra_delay = 1
+extra_delay = "1"
 # marker_prefix
 # Prepend a string to the track before it gets sent out.  Useful for indicating
 # some additional information to listeners.  This value must be quoted with
 # double-quotes in order to prevent trailing spaces from being stripped off.
-marker_prefix = "(Pre-Show) "
+marker_prefix = "\"(Pre-Show) \""
 # start_disabled
 # Prevent this plugin from immediately announcing its markers when the program
 # starts.
-start_disabled = True
+start_disabled = "True"
 
 #
 # plugin:OneEightyOneFM: Configure the 181.FM plugin
 #
-[plugin:OneEightyOneFM]
+["plugin:OneEightyOneFM"]
 # stream_url
 # The URL of the 181.FM stream to connect to.  Must be a direct link, not a
 # playlist link.  Also, only HTTP MP3 streams are supported, because they're
 # really easy to decode metadata from.
-stream_url = http://listen.livestreamingservice.com/181-eagle_128k.mp3
+stream_url = "http://listen.livestreamingservice.com/181-eagle_128k.mp3"
 # source_name
 # The bit in parentheses when this track is announced.
-source_name = from The Eagle at 181.FM
+source_name = "from The Eagle at 181.FM"
 # extra_delay
 # A floating-point number of seconds to delay announcements for.  Useful for
 # compensating for streaming delays from 181.FM to you.
-extra_delay = 1
+extra_delay = "1"
 # marker_prefix
 # Prepend a string to the track before it gets sent out.  Useful for indicating
 # some additional information to listeners.  This value must be quoted with
 # double-quotes in order to prevent trailing spaces from being stripped off.
-marker_prefix = "(Pre-Show) "
+marker_prefix = "\"(Pre-Show) \""
 # start_disabled
 # Prevent this plugin from immediately announcing its markers when the program
 # starts.
-start_disabled = True
+start_disabled = "True"

--- a/gelo.toml.example
+++ b/gelo.toml.example
@@ -16,7 +16,7 @@ macro_file="$HOME/.config/gelo/macros.ini"
 # broadcast_delay
 # How long the system should wait before pushing markers from a source to all of
 # the sinks.
-broadcast_delay = "8.0"
+broadcast_delay = 8.0
 
 #
 # plugin:HttpPoller: Configure the HTTP poller metadata source
@@ -51,21 +51,21 @@ prefix_file = "/tmp/prefix.txt"
 # consumer_key
 # The Twitter API key for this application, found under Keys and Access Tokens
 # on the Twitter Application Management page (apps.twitter.com)
-;consumer_key =""
+#consumer_key =""
 # consumer_secret
 # The Twitter API secret for this application, found under Keys and Access
 # Tokens on the Twitter Application Management page (apps.twitter.com)
-;consumer_secret =""
+#consumer_secret =""
 # access_token_key
 # The Twitter API access token to allow this app to tweet using your account,
 # found under Keys and Access Tokens on the Twitter Application Management page
 # (apps.twitter.com).
-;access_token_key =""
+#access_token_key =""
 # access_token_secret
 # The Twitter API access token secret to allow this app to tweet using your
 # account, found under Keys and Access Tokens on the Twitter Application
 # Management page (apps.twitter.com).
-;access_token_secret =""
+#access_token_secret =""
 
 # announce_string
 # The string that will be tweeted. "{marker}" will be substituted for the text
@@ -74,7 +74,7 @@ prefix_file = "/tmp/prefix.txt"
 announce_string="Now Playing{special}: {marker}"
 # delayed
 # Delay this plugin's output by the broadcast delay from above? Default True
-;delayed = "True"
+#delayed = true
 
 #
 # plugin:NowPlayingFile: A text file that contains a single line with the
@@ -87,7 +87,7 @@ announce_string="Now Playing{special}: {marker}"
 path="$HOME/Desktop/np.txt"
 # delayed
 # Delay this plugin's output by the broadcast delay from above? Default False
-;delayed = "False"
+#delayed = false
 
 
 #
@@ -98,31 +98,31 @@ path="$HOME/Desktop/np.txt"
 # The IRC nick to use when connecting
 nick="gelo"
 # nickserv_pass
-# The password to use when authenticating with NickServ. Set to the empty string
+# The password to use when authenticating with NickServ. Comment out this key
 # if you don't need that feature.
-nickserv_pass=""
+#nickserv_pass="secret"
 # server
 # The IRC server to connect to
 server="irc.example.com"
 # port
 # The TCP port to connect to on the IRC server
-port="6697"
+port=6697
 # tls
 # Enable TLS for the IRC connection.  Probably also in combination with
-# port="6697"
-tls="True"
+# port=6697
+tls=true
 # ipv6
 # Force the IRC connection over IPv6. I'm not entirely sure what the underlying
 # framework does with this, so maybe it falls back intelligently?
-ipv6="True"
+ipv6=true
 # send_to
 # The nick (or channel) to which to send messages
 send_to="#test"
 # repeat_with
 # Repeat the message with these strings (usually channels, although you could
-# get creative with it...).  Separate items with a comma. To disable this
-# behavior and just send one message, comment out this key.
-;repeat_with="#channel,#channel2,#channel3"
+# get creative with it...).  To disable this behavior and just send one message,
+# comment out this key.
+#repeat_with=["#channel1", "#channel2", "#channel3"]
 # message
 # The message to send. The group {marker} will be replaced with the marker text.
 # The group {special} will be replaced with a special indicator, if the marker
@@ -132,7 +132,7 @@ send_to="#test"
 message="Now Playing{special}: {marker}"
 # delayed
 # Delay this plugin's output by the broadcast delay from above? Default True
-;delayed = "True"
+#delayed = true
 
 #
 # plugin:AudacityLabels: Configure the Audacity Labels plugin
@@ -147,7 +147,7 @@ message="Now Playing{special}: {marker}"
 path="$HOME/Desktop/{show}-{count}.txt"
 # delayed
 # Delay this plugin's output by the broadcast delay from above? Default False
-;delayed = "False"
+#delayed = false
 
 #
 # plugin:HttpPusher: Configure the HTTP Pusher plugin
@@ -155,7 +155,7 @@ path="$HOME/Desktop/{show}-{count}.txt"
 ["plugin:HttpPusher"]
 # delayed
 # Delay this plugin's output by the broadcast delay from above? Default False
-;delayed = "False"
+#delayed = false
 
 # One of the webhooks for the HTTP Pusher plugin to send a request to.
 # Make more by copying this section and changing "example" in the section header to the
@@ -190,7 +190,7 @@ show_slug_param = "slug"
 show_episode_param = "episode"
 # extra_delay
 # Add more delay before sending markers to this webhook.  Positive delays only.
-extra_delay = "8.0"
+extra_delay = 8.0
 
 #
 # plugin:SomaFM: Configure the SomaFM plugin
@@ -207,7 +207,7 @@ source_name = "from Groove Salad on Soma.FM"
 # extra_delay
 # A floating-point number of seconds to delay announcements for.  Useful for
 # compensating for streaming delays from Soma.FM to you.
-extra_delay = "1"
+extra_delay = 1.0
 # marker_prefix
 # Prepend a string to the track before it gets sent out.  Useful for indicating
 # some additional information to listeners.  This value must be quoted with
@@ -216,7 +216,7 @@ marker_prefix = "\"(Pre-Show) \""
 # start_disabled
 # Prevent this plugin from immediately announcing its markers when the program
 # starts.
-start_disabled = "True"
+start_disabled = true
 
 #
 # plugin:OneEightyOneFM: Configure the 181.FM plugin
@@ -233,7 +233,7 @@ source_name = "from The Eagle at 181.FM"
 # extra_delay
 # A floating-point number of seconds to delay announcements for.  Useful for
 # compensating for streaming delays from 181.FM to you.
-extra_delay = "1"
+extra_delay = 1.0
 # marker_prefix
 # Prepend a string to the track before it gets sent out.  Useful for indicating
 # some additional information to listeners.  This value must be quoted with
@@ -242,4 +242,4 @@ marker_prefix = "\"(Pre-Show) \""
 # start_disabled
 # Prevent this plugin from immediately announcing its markers when the program
 # starts.
-start_disabled = "True"
+start_disabled = true

--- a/gelo/arch.py
+++ b/gelo/arch.py
@@ -117,17 +117,7 @@ class IMarkerSource(Thread, IPlugin):
     def __init__(self, config, mediator: IMediator, show: str):
         """Create a new marker source."""
         super().__init__()
-        if type(config) is ConfigParser:
-            if self.PLUGIN_MODULE_NAME is None:
-                raise ValueError("Plugins must define PLUGIN_MODULE_NAME.")
-            self.config = config["plugin:" + self.PLUGIN_MODULE_NAME]
-        elif type(config) is SectionProxy:
-            self.config = config
-        else:
-            raise ValueError(
-                "config must either be a ConfigParser object or "
-                "a SectionProxy object."
-            )
+        self.config = config
         self.mediator = mediator
         self.should_terminate = False
         self.show = show
@@ -189,17 +179,7 @@ class IMarkerSink(Thread, IPlugin):  # noqa: F811
         :mediator: The IMediator to get markers from
         :show: The short name of the show that the markers are for"""
         super().__init__()
-        if type(config) is ConfigParser:
-            if self.PLUGIN_MODULE_NAME is None:
-                raise ValueError("Plugins must define PLUGIN_MODULE_NAME.")
-            self.config = config["plugin:" + self.PLUGIN_MODULE_NAME]
-        elif type(config) is SectionProxy:
-            self.config = config
-        else:
-            raise ValueError(
-                "config must either be a ConfigParser object or "
-                "a SectionProxy object."
-            )
+        self.config = config
         self.mediator = mediator
         self.show = show
         self.should_terminate = False

--- a/gelo/command_line.py
+++ b/gelo/command_line.py
@@ -3,7 +3,7 @@ import os
 from gelo import main, conf
 import signal
 import argparse
-import configparser
+import toml
 
 GELO = main.Gelo()
 
@@ -18,7 +18,7 @@ def main():
     parser.add_argument(
         "-c",
         "--config",
-        default=os.path.expandvars("$HOME/.config/gelo/gelo.ini"),
+        default=os.path.expandvars("$HOME/.config/gelo/gelo.toml"),
         type=open,
         help="path to configuration file",
     )
@@ -37,8 +37,7 @@ def main():
     )
     args = parser.parse_args()
     # Parse the configuration file
-    config_file = configparser.ConfigParser()
-    config_file.read_file(args.config)
+    config_file = toml.load(args.config)
     # Create the Gelo Configuration
     config = conf.Configuration(config_file, args)
     # Add the handler to shut down Gelo

--- a/gelo/conf.py
+++ b/gelo/conf.py
@@ -46,11 +46,11 @@ class Configuration(object):
         if "broadcast_delay" not in config_file["core"].keys():
             errors.append("[core] is missing the required key " '"broadcast_delay"')
         else:
-            if not is_float(config_file["core"]["broadcast_delay"]):
+            if type(config_file["core"]["broadcast_delay"]) is not float:
                 errors.append(
                     "[core] has a non-float value for the key " '"broadcast_delay"'
                 )
-            elif float(config_file["core"]["broadcast_delay"]) < 0:
+            elif config_file["core"]["broadcast_delay"] < 0:
                 errors.append(
                     "[core] has a negative value for the key " '"broadcast_delay"'
                 )
@@ -77,49 +77,3 @@ class Configuration(object):
 
 class InvalidConfigurationError(Exception):
     """Used to indicate that the configuration is invalid."""
-
-
-def is_int(value: str) -> bool:
-    """Check to see if the value passed is an integer.
-
-    :return: True if the value can be converted to an integer,
-    False otherwise."""
-    try:
-        int(value)
-    except ValueError:
-        return False
-    else:
-        return True
-
-
-def is_float(value: str) -> bool:
-    """Check to see if the value passed is a float.
-
-    :return: True if the value can be converted to a float,
-    False otherwise."""
-    try:
-        float(value)
-    except ValueError:
-        return False
-    else:
-        return True
-
-
-def is_bool(value: str) -> bool:
-    """Check to see if the value passed is parsable as a boolean.
-
-    :return: True if ``value`` is one of yes, no, true, false, 1, 0, on, or off.
-    """
-    return value.lower() in ["yes", "no", "true", "false", "1", "0", "on", "off"]
-
-
-def as_bool(value: str) -> bool:
-    """Parse the value as a boolean.
-
-    :return: True if ``value`` parses as true, False if ``value`` parses as
-    false.
-    :raises: ValueError if ``value`` is not parsable as a boolean.
-    """
-    if not is_bool(value):
-        raise ValueError("%s cannot be coerced to a boolean" % value)
-    return value.lower() in ["yes", "true", "1", "on"]

--- a/gelo/conf.py
+++ b/gelo/conf.py
@@ -8,7 +8,7 @@ class Configuration(object):
     I split this out to reduce coupling between Gelo and ConfigParser."""
 
     def __init__(
-        self, config_file: configparser.ConfigParser, args: argparse.Namespace
+        self, config_file: dict, args: argparse.Namespace
     ):
         """Create a Configuration."""
         self.validate_config_file(config_file)
@@ -28,11 +28,11 @@ class Configuration(object):
         self.macro_file = os.path.expandvars(config_file["core"]["macro_file"])
         self.configparser = config_file
         self.show = args.show
-        self.broadcast_delay = float(config_file.get("core", "broadcast_delay"))
+        self.broadcast_delay = float(config_file["core"]["broadcast_delay"])
         self.log_level = self.get_log_level(args.verbose)
 
     @staticmethod
-    def validate_config_file(config_file: configparser.ConfigParser):
+    def validate_config_file(config_file: dict):
         """Check to see if the configuration file is valid.
         This is currently probably inadequate. It just looks for the [core]
         section."""
@@ -50,7 +50,7 @@ class Configuration(object):
                 errors.append(
                     "[core] has a non-float value for the key " '"broadcast_delay"'
                 )
-            elif float(config_file.get("core", "broadcast_delay")) < 0:
+            elif float(config_file["core"]["broadcast_delay"]) < 0:
                 errors.append(
                     "[core] has a negative value for the key " '"broadcast_delay"'
                 )

--- a/gelo/plugins/HttpPusher.gelo-plugin
+++ b/gelo/plugins/HttpPusher.gelo-plugin
@@ -3,7 +3,7 @@ Name = HttpPusher
 Module = HttpPusher
 
 [Documentation]
-Description = Connect to an HTTP(S) endpoint to send marker data
+Description = Connect to one or more HTTP(S) endpoints to send marker data
 Author = s0ph0s
-Version = 1.1.0
+Version = 2.0.0
 Website = https://github.com/s0ph0s-2/Gelo

--- a/gelo/plugins/HttpPusher.py
+++ b/gelo/plugins/HttpPusher.py
@@ -19,7 +19,7 @@ class HttpPusher(gelo.arch.IMarkerSink):
         self.validate_config()
         self.log.debug("Configuration valid")
         self.webhooks = self.config["webhooks"]
-        self.delayed = gelo.conf.as_bool(self.config["delayed"])
+        self.delayed = self.config["delayed"]
         show_split = show.split("-")
         if len(show_split) < 2:
             self.log.warning(
@@ -60,9 +60,14 @@ class HttpPusher(gelo.arch.IMarkerSink):
         """Make HTTP requests to every webhook."""
         for name, options in self.webhooks.items():
             if "extra_delay" in options.keys():
-                self.log.debug("Delaying marker for {} by {} seconds…".format(name, options["extra_delay"]))
-                delay = Timer(options["extra_delay"], self.request,
-                              args=[marker, name, options])
+                self.log.debug(
+                    "Delaying marker for {} by {} seconds…".format(
+                        name, options["extra_delay"]
+                    )
+                )
+                delay = Timer(
+                    options["extra_delay"], self.request, args=[marker, name, options]
+                )
                 delay.start()
             else:
                 self.log.debug("Sending marker for {} immediately…".format(name))
@@ -110,7 +115,7 @@ class HttpPusher(gelo.arch.IMarkerSink):
         if "delayed" not in self.config.keys():
             self.config["delayed"] = "False"
         else:
-            if not gelo.conf.is_bool(self.config["delayed"]):
+            if type(self.config["delayed"]) is not bool:
                 errors.append(
                     '["plugin:HttpPusher"] has a non-boolean value for the key "delayed"'
                 )
@@ -162,7 +167,7 @@ class HttpPusher(gelo.arch.IMarkerSink):
                 )
             )
         if "extra_delay" in webhook_options.keys():
-            if not gelo.conf.is_float(webhook_options["extra_delay"]):
+            if type(webhook_options["extra_delay"]) is not float:
                 errors.append(
                     '["plugin:HttpPusher".webhooks.{}] has a non-float value for the key "extra_delay"'.format(
                         webhook_name

--- a/gelo/plugins/IRC.gelo-plugin
+++ b/gelo/plugins/IRC.gelo-plugin
@@ -5,5 +5,5 @@ Module = IRC
 [Documentation]
 Description = Connect to an IRC server to send chapter marks.
 Author = s0ph0s
-Version = 2.1.0
+Version = 3.0.0
 Website = https://github.com/s0ph0s-2/Gelo

--- a/gelo/plugins/OneEightyOneFM.gelo-plugin
+++ b/gelo/plugins/OneEightyOneFM.gelo-plugin
@@ -5,5 +5,5 @@ Module = OneEightyOneFM
 [Documentation]
 Description = Announce track names from 181.FM
 Author = s0ph0s
-Version = 1.1.0
+Version = 2.0.0
 Website = https://github.com/s0ph0s-2/Gelo

--- a/gelo/plugins/OneEightyOneFM.py
+++ b/gelo/plugins/OneEightyOneFM.py
@@ -28,9 +28,9 @@ class OneEightyOneFM(arch.IMarkerSource):
         self.config_test()
         self.url = self.config["stream_url"]
         self.source_name = self.config["source_name"]
-        self.extra_delay = float(self.config["extra_delay"])
+        self.extra_delay = self.config["extra_delay"]
         self.marker_prefix = self.config["marker_prefix"].strip('"')
-        self.is_enabled = not conf.as_bool(self.config["start_disabled"])
+        self.is_enabled = not self.config["start_disabled"]
 
     def run(self):
         """Run the code that receives and posts markers.
@@ -120,38 +120,36 @@ class OneEightyOneFM(arch.IMarkerSource):
         errors = []
         if "stream_url" not in self.config:
             errors.append(
-                "[plugin:one_eighty_one_fm] does not have the "
-                'required key "stream_url"'
+                "[plugin:OneEightyOneFM] does not have the " 'required key "stream_url"'
             )
         if "source_name" not in self.config:
             errors.append(
-                "[plugin:one_eighty_one_fm] does not have the "
-                'required key "stream_url"'
+                '[plugin:OneEightyOneFM] does not have the required key "stream_url"'
             )
         if "extra_delay" not in self.config:
             errors.append(
-                "[plugin:one_eighty_one_fm] does not have the "
+                "[plugin:OneEightyOneFM] does not have the "
                 'required key "extra_delay"'
             )
-        elif not conf.is_float(self.config["extra_delay"]):
+        elif type(self.config["extra_delay"]) is not float:
             errors.append(
-                "[plugin:one_eighty_one_fm] does not have a float "
+                "[plugin:OneEightyOneFM] does not have a float "
                 'value for the key "extra_delay"'
             )
         if "start_disabled" not in self.config:
             errors.append(
-                "[plugin:one_eighty_one_fm] does not have the "
+                "[plugin:OneEightyOneFM] does not have the "
                 'required key "start_disabled"'
             )
-        elif not conf.is_bool(self.config["start_disabled"]):
+        elif type(self.config["start_disabled"]) is not bool:
             errors.append(
-                "[plugin:one_eighty_one_fm] does not have a "
+                "[plugin:OneEightyOneFM] does not have a "
                 "boolean-parseable value for the key "
                 '"start_disabled"'
             )
         if "marker_prefix" not in self.config:
             errors.append(
-                "[plugin:one_eighty_one_fm] does not have the "
+                "[plugin:OneEightyOneFM] does not have the "
                 'required key "marker_prefix"'
             )
 

--- a/gelo/plugins/SomaFM.gelo-plugin
+++ b/gelo/plugins/SomaFM.gelo-plugin
@@ -5,5 +5,5 @@ Module = SomaFM
 [Documentation]
 Description = Announce track names from Soma.FM
 Author = s0ph0s
-Version = 1.1.0
+Version = 2.0.0
 Website = https://github.com/s0ph0s-2/Gelo

--- a/gelo/plugins/SomaFM.py
+++ b/gelo/plugins/SomaFM.py
@@ -27,9 +27,9 @@ class SomaFM(arch.IMarkerSource):
         self.config_test()
         self.url = self.config["stream_url"]
         self.source_name = self.config["source_name"]
-        self.extra_delay = float(self.config["extra_delay"])
+        self.extra_delay = self.config["extra_delay"]
         self.marker_prefix = self.config["marker_prefix"].strip('"')
-        self.is_enabled = not conf.as_bool(self.config["start_disabled"])
+        self.is_enabled = not self.config["start_disabled"]
 
     def run(self):
         """Run the code that receives and posts markers.
@@ -118,35 +118,30 @@ class SomaFM(arch.IMarkerSource):
         """Verify this plugin's configuration."""
         errors = []
         if "stream_url" not in self.config:
-            errors.append(
-                "[plugin:somafm] does not have the required key" ' "stream_url"'
-            )
+            errors.append('[plugin:SomaFM] does not have the required key "stream_url"')
         if "source_name" not in self.config:
-            errors.append(
-                "[plugin:somafm] does not have the required key" ' "stream_url"'
-            )
+            errors.append('[plugin:SomaFM] does not have the required key "stream_url"')
         if "extra_delay" not in self.config:
             errors.append(
-                "[plugin:somafm] does not have the required key" ' "extra_delay"'
+                '[plugin:SomaFM] does not have the required key "extra_delay"'
             )
-        elif not conf.is_float(self.config["extra_delay"]):
+        elif type(self.config["extra_delay"]) is not float:
             errors.append(
-                "[plugin:somafm] does not have a float value for"
+                "[plugin:SomaFM] does not have a float value for"
                 ' the key "extra_delay"'
             )
         if "start_disabled" not in self.config:
             errors.append(
-                "[plugin:somafm] does not have the required key " '"start_disabled"'
+                '[plugin:SomaFM] does not have the required key "start_disabled"'
             )
-        elif not conf.is_bool(self.config["start_disabled"]):
+        elif type(self.config["start_disabled"]) is not bool:
             errors.append(
-                "[plugin:somafm] does not have a boolean-parseable"
+                "[plugin:SomaFM] does not have a boolean"
                 'value for the key "start_disabled"'
             )
         if "marker_prefix" not in self.config:
             errors.append(
-                "[plugin:one_eighty_one_fm] does not have the "
-                'required key "marker_prefix"'
+                '[plugin:SomaFM] does not have the required key "marker_prefix"'
             )
 
         if len(errors) > 0:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="gelo",
-    version="4.0.0",
+    version="4.1.0",
     description="podcast chapter metadata gathering tool for content creators",
     url="https://github.com/s0ph0s-2/Gelo",
     author="s0ph0s-2",
@@ -11,7 +11,7 @@ setup(
     packages=["gelo", "gelo.plugins"],
     package_dir={"gelo": "gelo", "gelo.plugins": "gelo/plugins"},
     package_data={"gelo": ["plugins/*.gelo-plugin"]},
-    install_requires=["yapsy>=1.12", "requests", "python-twitter", "irc"],
+    install_requires=["yapsy>=1.12", "requests", "python-twitter", "irc", "toml"],
     entry_points={
         "console_scripts": [
             "gelo = gelo.command_line:main",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="gelo",
-    version="4.1.0",
+    version="5.0.0",
     description="podcast chapter metadata gathering tool for content creators",
     url="https://github.com/s0ph0s-2/Gelo",
     author="s0ph0s-2",


### PR DESCRIPTION
Someone in IRC suggested that we have the pinned message in Telegram also say the current track. This change enables that ability by having multiple webhooks in the HttpPusher. It also required changing the config format to TOML from INI.